### PR TITLE
Feature: annotation view animations

### DIFF
--- a/PinFloyd.xcodeproj/project.pbxproj
+++ b/PinFloyd.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		D51AF8191E9449B4006E6555 /* MKMapPointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51AF80D1E94499B006E6555 /* MKMapPointTests.swift */; };
 		D51AF81A1E9449B4006E6555 /* MKMapRectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51AF80E1E94499B006E6555 /* MKMapRectTests.swift */; };
 		D51AF81B1E9449B4006E6555 /* MKMapSizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51AF80F1E94499B006E6555 /* MKMapSizeTests.swift */; };
+		D51AF81D1E944EEB006E6555 /* AnnotationAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51AF81C1E944EEB006E6555 /* AnnotationAnimation.swift */; };
 		D5B2E8AA1C3A780C00C0327D /* PinFloyd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5B2E89F1C3A780C00C0327D /* PinFloyd.framework */; };
 		D5CE51E71E92FCEC00744180 /* ClusterPin.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE51E61E92FCEC00744180 /* ClusterPin.swift */; };
 		D5CE51EC1E92FF8D00744180 /* ClusterPinTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE51EA1E92FF8800744180 /* ClusterPinTests.swift */; };
@@ -46,6 +47,7 @@
 		D51AF80E1E94499B006E6555 /* MKMapRectTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MKMapRectTests.swift; sourceTree = "<group>"; };
 		D51AF80F1E94499B006E6555 /* MKMapSizeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MKMapSizeTests.swift; sourceTree = "<group>"; };
 		D51AF8151E9449AE006E6555 /* CLLocationCoordinate2DTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CLLocationCoordinate2DTests.swift; sourceTree = "<group>"; };
+		D51AF81C1E944EEB006E6555 /* AnnotationAnimation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnnotationAnimation.swift; sourceTree = "<group>"; };
 		D5B2E89F1C3A780C00C0327D /* PinFloyd.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PinFloyd.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5B2E8A91C3A780C00C0327D /* PinFloyd-iOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "PinFloyd-iOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5C6298B1C3A8BBD007F7B7C /* Info-iOS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-iOS.plist"; sourceTree = "<group>"; };
@@ -127,12 +129,13 @@
 		D5C629691C3A809D007F7B7C /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				D5EEF1C11E939CB40081F824 /* Extensions */,
-				D5EEF1BB1E931F500081F824 /* QuadTreeNode.swift */,
-				D5EEF1C81E93A0DD0081F824 /* ClusteringManager.swift */,
-				D5EEF1AD1E9307070081F824 /* ClusterAnnotationView.swift */,
+				D51AF81C1E944EEB006E6555 /* AnnotationAnimation.swift */,
 				D5EEF1A91E9305C50081F824 /* ClusterAnnotation.swift */,
+				D5EEF1AD1E9307070081F824 /* ClusterAnnotationView.swift */,
+				D5EEF1C81E93A0DD0081F824 /* ClusteringManager.swift */,
 				D5CE51E61E92FCEC00744180 /* ClusterPin.swift */,
+				D5EEF1BB1E931F500081F824 /* QuadTreeNode.swift */,
+				D5EEF1C11E939CB40081F824 /* Extensions */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -150,12 +153,12 @@
 		D5CE51E91E92FF8800744180 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				D51AF80A1E94496D006E6555 /* Extensions */,
-				D5CE51EA1E92FF8800744180 /* ClusterPinTests.swift */,
 				D5EEF1AB1E9305E30081F824 /* ClusterAnnotationTests.swift */,
 				D5EEF1AF1E93082F0081F824 /* ClusterAnnotationViewTests.swift */,
-				D5EEF1BD1E9389760081F824 /* QuadTreeNodeTests.swift */,
 				D5EEF1CA1E93A2330081F824 /* ClusteringManagerTests.swift */,
+				D5CE51EA1E92FF8800744180 /* ClusterPinTests.swift */,
+				D5EEF1BD1E9389760081F824 /* QuadTreeNodeTests.swift */,
+				D51AF80A1E94496D006E6555 /* Extensions */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -292,6 +295,7 @@
 				D5EEF1C91E93A0DD0081F824 /* ClusteringManager.swift in Sources */,
 				D5EEF1C41E939CC90081F824 /* MKGeometry+PinFloyd.swift in Sources */,
 				D5EEF1AA1E9305C50081F824 /* ClusterAnnotation.swift in Sources */,
+				D51AF81D1E944EEB006E6555 /* AnnotationAnimation.swift in Sources */,
 				D5EEF1BC1E931F500081F824 /* QuadTreeNode.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/AnnotationAnimation.swift
+++ b/Sources/AnnotationAnimation.swift
@@ -1,0 +1,68 @@
+import MapKit
+
+// Annotation animation
+
+public enum AnnotationAnimation {
+  case bounce, fade
+
+  func createAnimator() -> AnnotationAnimator {
+    switch self {
+    case .bounce:
+      return BounceAnnotationAnimator()
+    case .fade:
+      return FadeAnnotationAnimator()
+    }
+  }
+}
+
+// MARK: - Protocol
+
+protocol AnnotationAnimator {
+  func animate(views: [MKAnnotationView])
+  func animate(view: MKAnnotationView)
+}
+
+extension AnnotationAnimator {
+
+  func animate(views: [MKAnnotationView]) {
+    for view in views {
+      animate(view: view)
+    }
+  }
+}
+
+// MARK: - Bounce
+
+final class BounceAnnotationAnimator: AnnotationAnimator {
+
+  func animate(view: MKAnnotationView) {
+    let animationKey = "annotationBounce"
+    let animation = CAKeyframeAnimation.init(keyPath: "transform.scale")
+    var timingFunctions = [CAMediaTimingFunction]()
+
+    animation.values = [0.5, 1.1, 0.9, 1]
+    animation.duration = 0.5
+
+    for _ in 0..<4 {
+      timingFunctions.append(CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut))
+    }
+
+    animation.timingFunctions = timingFunctions
+    animation.isRemovedOnCompletion = false
+
+    view.layer.add(animation, forKey: animationKey)
+  }
+}
+
+// MARK: - Fade
+
+final class FadeAnnotationAnimator: AnnotationAnimator {
+
+  func animate(view: MKAnnotationView) {
+    view.alpha = 0
+
+    UIView.animate(withDuration: 0.3) {
+      view.alpha = 1
+    }
+  }
+}

--- a/Sources/ClusteringManager.swift
+++ b/Sources/ClusteringManager.swift
@@ -58,6 +58,11 @@ public final class ClusteringManager {
     return clusterView
   }
 
+  public func animate(annotationViews: [MKAnnotationView], animation: AnnotationAnimation = .bounce) {
+    let animator = animation.createAnimator()
+    animator.animate(views: annotationViews)
+  }
+
   private func clusterAnnotation(for coordinate: CLLocationCoordinate2D,
                                  annotationsCount: Int,
                                  visibleAnnotations: [MKAnnotation]) -> MKAnnotation {


### PR DESCRIPTION
It's nice to animate annotation views when they appear on the map. So here we have 2 animations types (`bounce` and `fade`) that could be applied like this:

```swift
func mapView(_ mapView: MKMapView, didAdd views: [MKAnnotationView]) {
  clusteringManager.animate(annotationViews: views, animation: .bounce)
}
```