### PR TITLE
Improve: clustering manager

### DIFF
--- a/Sources/ClusterAnnotation.swift
+++ b/Sources/ClusterAnnotation.swift
@@ -12,4 +12,15 @@ public class ClusterAnnotation: NSObject, MKAnnotation {
     self.coordinate = coordinate
     self.annotationsCount = annotationsCount
   }
+
+  public override func isEqual(_ object: Any?) -> Bool {
+    if let rhs = object as? ClusterAnnotation {
+      return annotationsCount == rhs.annotationsCount && coordinate == rhs.coordinate
+    }
+    return super.isEqual(object)
+  }
+
+  public override var hash: Int {
+    return annotationsCount.hashValue ^ coordinate.latitude.hashValue ^ coordinate.longitude.hashValue
+  }
 }

--- a/Sources/ClusteringManager.swift
+++ b/Sources/ClusteringManager.swift
@@ -30,8 +30,8 @@ public final class ClusteringManager {
   }
 
   public func renderAnnotations(onMapView mapView: MKMapView, completion: Completion? = nil) {
-    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-      guard let strongSelf = self else {
+    DispatchQueue.global(qos: .userInitiated).async { [weak self, weak mapView] in
+      guard let strongSelf = self, let mapView = mapView else {
         return
       }
 
@@ -85,6 +85,10 @@ public final class ClusteringManager {
   // MARK: - Clustering
 
   private func clusteredAnnotations(onMapView mapView: MKMapView) -> [MKAnnotation] {
+    guard !mapView.zoomScale.isInfinite else {
+      return []
+    }
+
     let tile = mapView.tile
     let scaleFactor = mapView.scaleFactor
     let visibleAnnotations = mapView.annotations
@@ -156,7 +160,11 @@ public final class ClusteringManager {
     setToRemove.minus(newSet)
 
     // Reload annotations
-    DispatchQueue.main.async {
+    DispatchQueue.main.async { [weak mapView] in
+      guard let mapView = mapView else {
+        return
+      }
+
       if let toAddAnnotations = setToAdd.allObjects as? [MKAnnotation] {
         mapView.addAnnotations(toAddAnnotations)
       }

--- a/Sources/ClusteringManager.swift
+++ b/Sources/ClusteringManager.swift
@@ -16,9 +16,13 @@ public final class ClusteringManager {
   // MARK: - Annotations
 
   public func add(annotations: [MKAnnotation]) {
+    lock.lock()
+
     for annotation in annotations {
       rootNode.add(annotation: annotation)
     }
+
+    lock.unlock()
   }
 
   public func replace(annotations: [MKAnnotation]) {
@@ -76,6 +80,8 @@ public final class ClusteringManager {
     let scaleFactor = mapView.scaleFactor
     var clusteredAnnotations = [MKAnnotation]()
 
+    lock.lock()
+
     // Iterate through the bounding box points
     for x in tile.minX...tile.maxX {
       for y in tile.minY...tile.maxY {
@@ -116,6 +122,8 @@ public final class ClusteringManager {
         }
       }
     }
+
+    lock.unlock()
 
     return clusteredAnnotations
   }


### PR DESCRIPTION
1) Compare cluster annotations to no update the item with the same coordinate.
2) Use `NSRecursiveLock` during computations and when annotations are being added to the tree.
3) Validate zoomLevel to be not infinite.