### PR TITLE
Slice the annotations array

### DIFF
--- a/Sources/ClusteringManager.swift
+++ b/Sources/ClusteringManager.swift
@@ -152,7 +152,7 @@ public final class ClusteringManager {
   // Add only the annotations we need in the current region
   // https://robots.thoughtbot.com/how-to-handle-large-amounts-of-data-on-maps#adding-only-the-annotations-we-need
   private func reload(annotations: [MKAnnotation], onMapView mapView: MKMapView, completion: Completion?) {
-    let currentSet = NSMutableSet(array: mapView.annotations)
+    let currentSet = NSMutableSet(array: mapView.annotations.filter(filterAnnotations))
     let newSet = NSSet(array: annotations) as Set<NSObject>
 
     // Remove user location

--- a/Sources/ClusteringManager.swift
+++ b/Sources/ClusteringManager.swift
@@ -23,7 +23,10 @@ public final class ClusteringManager {
   public func add(annotations: [MKAnnotation]) {
     lock.lock()
 
-    for annotation in annotations {
+    let tuple = slice(annotations: annotations)
+    unclusteredAnnotations.append(contentsOf: tuple.unclustered)
+
+    for annotation in tuple.toBeClustered {
       rootNode.add(annotation: annotation)
     }
 
@@ -33,10 +36,9 @@ public final class ClusteringManager {
   public func replace(annotations: [MKAnnotation]) {
     removeAll()
 
-    unclusteredAnnotations.append(
-      contentsOf: annotations.filter({ !filterAnnotations($0) })
-    )
-    add(annotations: annotations.filter(filterAnnotations))
+    let tuple = slice(annotations: annotations)
+    unclusteredAnnotations.append(contentsOf: tuple.unclustered)
+    add(annotations: tuple.toBeClustered)
   }
 
   public func removeAll() {
@@ -184,6 +186,13 @@ public final class ClusteringManager {
 
       completion?(mapView)
     }
+  }
+
+  private func slice(annotations: [MKAnnotation])
+    -> (toBeClustered: [MKAnnotation], unclustered: [MKAnnotation]) {
+      let toBeClustered = annotations.filter(filterAnnotations)
+      let unclusterd = annotations.filter({ !filterAnnotations($0) })
+      return (toBeClustered, unclusterd)
   }
 }
 


### PR DESCRIPTION
- If we use PinFloyd, we should always use PinFloyd, because in the `reload` methods, we did some intersection, union without regarding the current status of the map. 
- We should not call `mapView.addAnnotation` manually, instead we should use PinkFloyd to add annotation, then call `render`. This add `slice` as a common methods to get unclustered and to-be-clustered annotations, both for `replace` and `add`